### PR TITLE
Add new hexpired notification for HFE 

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3195,6 +3195,8 @@ typedef struct dictExpireMetadata {
 #define HFE_LAZY_EXPIRE           (0) /* Delete expired field, and if last field also the hash */
 #define HFE_LAZY_AVOID_FIELD_DEL  (1<<0) /* Avoid deleting expired field */
 #define HFE_LAZY_AVOID_HASH_DEL   (1<<1) /* Avoid deleting hash if the field is the last one */
+#define HFE_LAZY_NO_NOTIFICATION  (1<<2) /* Do not send notification, used when multiple fields
+                                          * may expire and only one notification is desired. */
 
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires);
 void hashTypeTryConversion(redisDb *db, robj *subject, robj **argv, int start, int end);

--- a/src/server.h
+++ b/src/server.h
@@ -3191,9 +3191,14 @@ typedef struct dictExpireMetadata {
 #define HASH_SET_TAKE_VALUE (1<<1)
 #define HASH_SET_COPY 0
 
+/* Hash field lazy expiration flags. Used by core hashTypeGetValue() and its callers */
+#define HFE_LAZY_EXPIRE           (0) /* Delete expired field, and if last field also the hash */
+#define HFE_LAZY_AVOID_FIELD_DEL  (1<<0) /* Avoid deleting expired field */
+#define HFE_LAZY_AVOID_HASH_DEL   (1<<1) /* Avoid deleting hash if the field is the last one */
+
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires);
 void hashTypeTryConversion(redisDb *db, robj *subject, robj **argv, int start, int end);
-int hashTypeExists(redisDb *db, robj *o, sds key, int *isHashDeleted);
+int hashTypeExists(redisDb *db, robj *o, sds key, int hfeFlags, int *isHashDeleted);
 int hashTypeDelete(robj *o, void *key, int isSdsField);
 unsigned long hashTypeLength(const robj *o, int subtractExpiredFields);
 hashTypeIterator *hashTypeInitIterator(robj *subject);
@@ -3210,7 +3215,7 @@ void hashTypeCurrentObject(hashTypeIterator *hi, int what, unsigned char **vstr,
                            unsigned int *vlen, long long *vll, uint64_t *expireTime);
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
 hfield hashTypeCurrentObjectNewHfield(hashTypeIterator *hi);
-robj *hashTypeGetValueObject(redisDb *db, robj *o, sds field, int *isHashDeleted);
+robj *hashTypeGetValueObject(redisDb *db, robj *o, sds field, int hfeFlags, int *isHashDeleted);
 int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags);
 robj *hashTypeDup(robj *o, sds newkey, uint64_t *minHashExpire);
 uint64_t hashTypeRemoveFromExpires(ebuckets *hexpires, robj *o);

--- a/src/sort.c
+++ b/src/sort.c
@@ -95,7 +95,7 @@ robj *lookupKeyByPattern(redisDb *db, robj *pattern, robj *subst) {
         /* Retrieve value from hash by the field name. The returned object
          * is a new object with refcount already incremented. */
         int isHashDeleted;
-        o = hashTypeGetValueObject(db, o, fieldobj->ptr, &isHashDeleted);
+        o = hashTypeGetValueObject(db, o, fieldobj->ptr, HFE_LAZY_EXPIRE, &isHashDeleted);
 
         if (isHashDeleted)
             goto noobj;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2227,7 +2227,7 @@ void hmgetCommand(client *c) {
             deleted += (res == GETF_EXPIRED_HASH);
         } else {
             /* If hash got lazy expired since all fields are expired (o is invalid),
-            * then fill the rest with trivial nulls and return */
+             * then fill the rest with trivial nulls and return. */
             addReplyNull(c);
         }
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -754,7 +754,6 @@ GetFieldRes hashTypeGetValue(redisDb *db, robj *o, sds field, unsigned char **vs
     robj *keyObj = createStringObject(key, sdslen(key));
     notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", keyObj, db->id);
     if ((hashTypeLength(o, 0) == 0) && (!(hfeFlags & HFE_LAZY_AVOID_HASH_DEL))) {
-        robj *keyObj = createStringObject(key, sdslen(key));
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", keyObj, db->id);
         dbDelete(db,keyObj);
         res = GETF_EXPIRED_HASH;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2212,7 +2212,7 @@ void hmgetCommand(client *c) {
     GetFieldRes res = GETF_OK;
     robj *o;
     int i;
-    int expired = 0, deleted = 0;;
+    int expired = 0, deleted = 0;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * hashes, where HMGET should respond with a series of null bulks. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -14,13 +14,23 @@
  * update the expiration time of the hash object in global HFE DS. */
 #define HASH_NEW_EXPIRE_DIFF_THRESHOLD max(4000, 1<<EB_BUCKET_KEY_PRECISION)
 
-/* Returned by hashTypeGetValue() */
+/* Reserve 2 bits out of hash-field expiration time for possible future lightweight
+ * indexing/categorizing of fields. It can be achieved by hacking HFE as follows:
+ *
+ *    HPEXPIREAT key [ 2^47 + USER_INDEX ] FIELDS numfields field [field …]
+ *
+ * Redis will also need to expose kind of HEXPIRESCAN and HEXPIRECOUNT for this
+ * idea. Yet to be better defined.
+ *
+ * HFE_MAX_ABS_TIME_MSEC constraint must be enforced only at API level. Internally,
+ * the expiration time can be up to EB_EXPIRE_TIME_MAX for future readiness.
+ */
+#define HFE_MAX_ABS_TIME_MSEC (EB_EXPIRE_TIME_MAX >> 2)
+
 typedef enum GetFieldRes {
     /* common (Used by hashTypeGet* value family) */
-    GETF_OK = 0,
+    GETF_OK = 0,            /* The field was found. */
     GETF_NOT_FOUND,         /* The field was not found. */
-
-    /* used only by hashTypeGetValue() */
     GETF_EXPIRED,           /* Logically expired (Might be lazy deleted or not) */
     GETF_EXPIRED_HASH,      /* Delete hash since retrieved field was expired and
                              * it was the last field in the hash. */
@@ -168,10 +178,7 @@ static inline int isDictWithMetaHFE(dict *d) {
 
 /* Returned value of hashTypeSetEx() */
 typedef enum SetExRes {
-    /* Common res from hashTypeSetEx() */
     HSETEX_OK =                1,   /* Expiration time set/updated as expected */
-
-    /* If provided HashTypeSetEx struct to hashTypeSetEx() */
     HSETEX_NO_FIELD =         -2,   /* No such hash-field */
     HSETEX_NO_CONDITION_MET =  0,   /* Specified NX | XX | GT | LT condition not met */
     HSETEX_DELETED =           2,   /* Field deleted because the specified time is in the past */
@@ -183,23 +190,12 @@ typedef enum GetExpireTimeRes {
     HFE_GET_NO_TTL =            -1, /* No TTL attached to the field */
 } GetExpireTimeRes;
 
-typedef enum FieldGet { /* TBD */
-    FIELD_GET_NONE = 0,
-    FIELD_GET_NEW  = 1,
-    FIELD_GET_OLD  = 2
-} FieldGet;
-
 typedef enum ExpireSetCond {
     HFE_NX = 1<<0,
     HFE_XX = 1<<1,
     HFE_GT = 1<<2,
     HFE_LT = 1<<3
 } ExpireSetCond;
-
-typedef struct HashTypeSet {
-    sds value;
-    int flags;
-} HashTypeSet;
 
 /* Used by hashTypeSetEx() for setting fields or their expiry  */
 typedef struct HashTypeSetEx {
@@ -2933,7 +2929,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
     }
 
     if (unit == UNIT_SECONDS) {
-        if (expire > (long long) EB_EXPIRE_TIME_MAX / 1000) {
+        if (expire > (long long) HFE_MAX_ABS_TIME_MSEC / 1000) {
             addReplyErrorExpireTime(c);
             return;
         }
@@ -2941,7 +2937,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
     }
 
     /* Ensure that the final absolute Unix timestamp does not exceed EB_EXPIRE_TIME_MAX. */
-    if (expire > (long long) EB_EXPIRE_TIME_MAX - basetime) {
+    if (expire > (long long) HFE_MAX_ABS_TIME_MSEC - basetime) {
         addReplyErrorExpireTime(c);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1157,6 +1157,7 @@ void hashTypeSetExDone(HashTypeSetEx *ex) {
         if (ex->fieldDeleted && hashTypeLength(ex->hashObj, 0) == 0) {
             dbDelete(ex->db,ex->key);
             signalModifiedKey(ex->c, ex->db, ex->key);
+            notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", ex->key, ex->db->id);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"del",ex->key, ex->db->id);
         } else {
             signalModifiedKey(ex->c, ex->db, ex->key);

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -429,8 +429,8 @@ start_server [list overrides [list "dir" $server_path]] {
             r HMSET key a 1 b 2 c 3 d 4 e 5
             # expected to be expired long after restart
             r HEXPIREAT key 2524600800 FIELDS 1 a
-            # expected long TTL value (6 bytes) is saved and loaded correctly
-            r HPEXPIREAT key 188900976391764 FIELDS 1 b
+            # expected long TTL value (46 bits) is saved and loaded correctly
+            r HPEXPIREAT key 65755674080852 FIELDS 1 b
             # expected to be already expired after restart
             r HPEXPIRE key 80 FIELDS 1 d
             # expected to be expired soon after restart
@@ -443,7 +443,7 @@ start_server [list overrides [list "dir" $server_path]] {
             wait_done_loading r
 
             assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
-            assert_equal [r hpexpiretime key FIELDS 3 a b c] {2524600800000 188900976391764 -1}
+            assert_equal [r hpexpiretime key FIELDS 3 a b c] {2524600800000 65755674080852 -1}
             assert_equal [s rdb_last_load_keys_loaded] 1
 
             # wait until expired_hash_fields equals 2

--- a/tests/unit/moduleapi/hash.tcl
+++ b/tests/unit/moduleapi/hash.tcl
@@ -21,6 +21,45 @@ start_server {tags {"modules"}} {
         r hgetall k
     } {squirrel ofcourse banana no what nothing something nice}
 
+    test {Module hash - set (override) NX expired field successfully} {
+        r debug set-active-expire 0
+        r del H1 H2
+        r hash.set H1 "n" f1 v1
+        r hpexpire H1 1 FIELDS 1 f1
+        r hash.set H2 "n" f1 v1 f2 v2
+        r hpexpire H2 1 FIELDS 1 f1
+        after 5
+        assert_equal 0 [r hash.set H1 "n" f1 xx]
+        assert_equal "f1 xx" [r hgetall H1]
+        assert_equal 0 [r hash.set H2 "n" f1 yy]
+        assert_equal "f1 f2 v2 yy" [lsort [r hgetall H2]]
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
+    test {Module hash - set XX of expired field gets failed as expected} {
+        r debug set-active-expire 0
+        r del H1 H2
+        r hash.set H1 "n" f1 v1
+        r hpexpire H1 1 FIELDS 1 f1
+        r hash.set H2 "n" f1 v1 f2 v2
+        r hpexpire H2 1 FIELDS 1 f1
+        after 5
+
+        # expected to fail on condition XX. hgetall should return empty list
+        r hash.set H1 "x" f1 xx
+        assert_equal "" [lsort [r hgetall H1]]
+        # But expired field was not lazy deleted
+        assert_equal 1 [r hlen H1]
+
+        # expected to fail on condition XX. hgetall should return list without expired f1
+        r hash.set H2 "x" f1 yy
+        assert_equal "f2 v2" [lsort [r hgetall H2]]
+        # But expired field was not lazy deleted
+        assert_equal 2 [r hlen H2]
+
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     test "Unload the module - hash" {
         assert_equal {OK} [r module unload hash]
     }

--- a/tests/unit/moduleapi/scan.tcl
+++ b/tests/unit/moduleapi/scan.tcl
@@ -25,12 +25,16 @@ start_server {tags {"modules"}} {
     } {{f1 1}}
 
     test {Module scan hash listpack with hexpire} {
-        r hmset hh f1 v1 f2 v2
+        r debug set-active-expire 0
+        r hmset hh f1 v1 f2 v2 f3 v3
         r hexpire hh 100000 fields 1 f1
+        r hpexpire hh 1 fields 1 f3
+        after 10
         assert_range [r httl hh fields 1 f1] 10000 100000
         assert_encoding listpackex hh
+        r debug set-active-expire 1
         lsort [r scan.scan_key hh]
-    } {{f1 v1} {f2 v2}}
+    } {{f1 v1} {f2 v2}} {needs:debug}
 
     test {Module scan hash dict} {
         r config set hash-max-ziplist-entries 2
@@ -44,10 +48,22 @@ start_server {tags {"modules"}} {
         r del hh
         r hmset hh f1 v1 f2 v2 f3 v3
         r hexpire hh 100000 fields 1 f2
+        r hpexpire hh 5 fields 1 f3
         assert_range [r httl hh fields 1 f2] 10000 100000
         assert_encoding hashtable hh
+        after 10
         lsort [r scan.scan_key hh]
-    } {{f1 v1} {f2 v2} {f3 v3}}
+    } {{f1 v1} {f2 v2}}
+
+    test {Module scan hash with hexpire can return no items} {
+        r del hh
+        r debug set-active-expire 0
+        r hmset hh f1 v1 f2 v2 f3 v3
+        r hpexpire hh 1 fields 3 f1 f2 f3
+        after 10
+        r debug set-active-expire 1
+        lsort [r scan.scan_key hh]
+    } {} {needs:debug}
 
     test {Module scan zset listpack} {
         r zadd zz 1 f1 2 f2

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -392,7 +392,7 @@ start_server {tags {"pubsub network"}} {
         r hmget myhash f1 f2 ;# Trigger lazy expire
         # We should get only one `hexpired` notification even two fields was expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
-        # We should get a `del` notificaion after all fields were expired.
+        # We should get a `del` notification after all fields were expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash del" [$rd1 read]
         r debug set-active-expire 1
 

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -392,7 +392,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
 
         # Test that we will get `hexpired` notification when
-        # a hash field is removed by lazy active.
+        # a hash field is removed by lazy expire.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 2 f1 f2
         after 20

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -360,7 +360,7 @@ start_server {tags {"pubsub network"}} {
         r del myhash
         set rd1 [redis_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
-        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 1
+        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 3
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -360,7 +360,7 @@ start_server {tags {"pubsub network"}} {
         r del myhash
         set rd1 [redis_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
-        r hmset myhash yes 1 no 0 f1 1 f2 2
+        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 1
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no
@@ -379,17 +379,25 @@ start_server {tags {"pubsub network"}} {
         # Test that we will get `hexpired` notification when
         # a hash field is removed by active expire.
         r hpexpire myhash 10 FIELDS 1 no
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 100 ;# Wait for active expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
+
+        # Test that when a field with TTL is deleted by commands like hdel without
+        # updating the global DS, active expire will not send a notification.
+        r hpexpire myhash 100 FIELDS 1 f3_hdel
+        r hdel myhash f3_hdel
+        after 200 ;# Wait for active expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
+        assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
 
         # Test that we will get `hexpired` notification when
         # a hash field is removed by lazy active.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 2 f1 f2
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 20
         r hmget myhash f1 f2 ;# Trigger lazy expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         # We should get only one `hexpired` notification even two fields was expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
         # We should get a `del` notification after all fields were expired.

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -394,7 +394,7 @@ start_server {tags {"pubsub network"}} {
         r debug set-active-expire 1
 
         $rd1 close
-    }
+    } {0} {needs:debug}
     } ;# foreach
 
     test "Keyspace notifications: stream events test" {

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -376,15 +376,15 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hpersist" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that we wll get `hexpired` notification when
-        # a hash fied is removed by active expire.
+        # Test that we will get `hexpired` notification when
+        # a hash field is removed by active expire.
         r hpexpire myhash 10 FIELDS 1 f1
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 100 ;# Wait for active expire
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that we wll get `hexpired` notification when
-        # a hash fied is removed by lazy active.
+        # Test that we will get `hexpired` notification when
+        # a hash field is removed by lazy active.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 1 f2
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -360,7 +360,7 @@ start_server {tags {"pubsub network"}} {
         r del myhash
         set rd1 [redis_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
-        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 3
+        r hmset myhash yes 1 no 0 f1 1 f2 2
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no
@@ -376,32 +376,21 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hpersist" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that we will get `hexpired` notification when
-        # a hash field is removed by active expire.
-        r hpexpire myhash 10 FIELDS 1 no
+        # Test that we wll get `hexpired` notification when
+        # a hash fied is removed by active expire.
+        r hpexpire myhash 10 FIELDS 1 f1
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 100 ;# Wait for active expire
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that when a field with TTL is deleted by commands like hdel without
-        # updating the global DS, active expire will not send a notification.
-        r hpexpire myhash 100 FIELDS 1 f3_hdel
-        r hdel myhash f3_hdel
-        after 200 ;# Wait for active expire
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
-        assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
-
-        # Test that we will get `hexpired` notification when
-        # a hash field is removed by lazy expire.
+        # Test that we wll get `hexpired` notification when
+        # a hash fied is removed by lazy active.
         r debug set-active-expire 0
-        r hpexpire myhash 10 FIELDS 2 f1 f2
-        after 20
-        r hmget myhash f1 f2 ;# Trigger lazy expire
+        r hpexpire myhash 10 FIELDS 1 f2
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
-        # We should get only one `hexpired` notification even two fields was expired.
+        after 20
+        r hstrlen myhash f2 ;# Trigger lazy expire
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
-        # We should get a `del` notification after all fields were expired.
-        assert_equal "pmessage * __keyspace@${db}__:myhash del" [$rd1 read]
         r debug set-active-expire 1
 
         $rd1 close

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -208,12 +208,12 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_error {*Parameter `numFields` is more than number of arguments} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
         }
 
-        test "HPEXPIRE - parameter expire-time near limit of  2^48 ($type)" {
+        test "HPEXPIRE - parameter expire-time near limit of  2^46 ($type)" {
             r del myhash
             r hset myhash f1 v1
             # below & above
-            assert_equal [r hpexpire myhash [expr (1<<48) - [clock milliseconds] - 1000 ] FIELDS 1 f1] [list  $E_OK]
-            assert_error {*invalid expire time*} {r hpexpire myhash [expr (1<<48) - [clock milliseconds] + 100 ] FIELDS 1 f1}
+            assert_equal [r hpexpire myhash [expr (1<<46) - [clock milliseconds] - 1000 ] FIELDS 1 f1] [list  $E_OK]
+            assert_error {*invalid expire time*} {r hpexpire myhash [expr (1<<46) - [clock milliseconds] + 100 ] FIELDS 1 f1}
         }
 
         test "Lazy Expire - fields are lazy deleted ($type)" {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1103,8 +1103,11 @@ start_server {tags {"external:skip needs:debug"}} {
             r hexpireat h1 [expr [clock seconds]+100] NX FIELDS 1 f1
             r hset h2 f2 v2
             r hpexpireat h2 [expr [clock seconds]*1000+100000] NX FIELDS 1 f2
-            r hset h3 f3 v3 f4 v4
+            r hset h3 f3 v3 f4 v4 f5 v5
+            # hpersist does nothing here. Verify it is not propagated.
+            r hpersist h3 FIELDS 1 f5
             r hexpire h3 100 FIELDS 3 f3 f4 non_exists_field
+            r hpersist h3 FIELDS 1 f3
 
             assert_replication_stream $repl {
                 {select *}
@@ -1112,8 +1115,9 @@ start_server {tags {"external:skip needs:debug"}} {
                 {hpexpireat h1 * NX FIELDS 1 f1}
                 {hset h2 f2 v2}
                 {hpexpireat h2 * NX FIELDS 1 f2}
-                {hset h3 f3 v3 f4 v4}
+                {hset h3 f3 v3 f4 v4 f5 v5}
                 {hpexpireat h3 * FIELDS 3 f3 f4 non_exists_field}
+                {hpersist h3 FIELDS 1 f3}
             }
             close_replication_stream $repl
         } {} {needs:repl}


### PR DESCRIPTION
When the hash field expired, we will send a new hexpired notification.
It mainly includes the following three cases:

1. When field expired by active expiration.
2. When field expired by lazy expiration.
3. When the user uses the h(p)expire(at) command, the user will also get a hexpired notification if the field expires during the command.

## Improvement
1. Now if more than one field expires in the hmget command, we will only send a hexpired notification.
2. When a field with TTL is deleted by commands like hdel without updating the global DS, active expire will not send a notification.